### PR TITLE
Fix for installation issue and bugs in sample code in Python 3

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/jfdm/pyPEBEL',
     license='BSD-new',
     description='A python 3.x module to support the use of the IBE, ABE, and PBE family of asymmetric encryption schemes within python scripts and modules.',
-    long_description=open('README.markdown').read(),
+    long_description=open('README.md').read(),
     install_requires=[
         "setuptools",
         "pyparsing >= 1.5.5",

--- a/scripts/pyCPABE-decrypt.py
+++ b/scripts/pyCPABE-decrypt.py
@@ -67,7 +67,7 @@ def main():
     else:
         with io.open(ptxt_fname, 'wb') as ptxt:
             for b in raw:
-                ptxt.write(bytes(b))
+                ptxt.write(bytes([b]))
                 ptxt.flush()
 
 if __name__ == '__main__':

--- a/scripts/pyCPABE-encrypt.py
+++ b/scripts/pyCPABE-encrypt.py
@@ -52,7 +52,7 @@ def main():
 
     with io.open(ctxt_fname, 'wb') as ctxt_file:
         for b in ctxt:
-            ctxt_file.write(bytes(b))
+            ctxt_file.write(bytes([b]))
 
 
 if __name__ == '__main__':

--- a/scripts/pyKPABE-decrypt.py
+++ b/scripts/pyKPABE-decrypt.py
@@ -66,7 +66,7 @@ def main():
     else:
         with io.open(ptxt_fname, 'wb') as ptxt:
             for b in raw:
-                ptxt.write(bytes(b))
+                ptxt.write(bytes([b]))
                 ptxt.flush()
 
 if __name__ == '__main__':

--- a/scripts/pyKPABE-encrypt.py
+++ b/scripts/pyKPABE-encrypt.py
@@ -57,8 +57,8 @@ def main():
 
     with io.open(ctxt_fname, 'wb') as ctxt_file:
         for b in ctxt:
-            ctxt_file.write(bytes(b))
-            
+            ctxt_file.write(bytes([b]))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- The installation was failing because of the mismatch in the filenames of README file. 
  - Fixed by correcting the file name in code
- None of the sample scripts in scripts folder were generating the correct encrypted/decrypted file.
  - Fixed by changing ptxt.write(bytes(b)) to ptxt.write(bytes([b])) as bytes() expects a list as parameter.
